### PR TITLE
fix: leaking id of user's linked-accounts

### DIFF
--- a/src/features/user/service/user.service.ts
+++ b/src/features/user/service/user.service.ts
@@ -15,7 +15,7 @@ import { SocketConnectionService } from './socket-connection.service';
 
 @Injectable()
 export class UserService {
-  private filteredFields: (keyof User)[] = ['password', 'sessionToken'];
+  private filteredFields: (keyof User)[] = ['password', 'sessionToken', 'facebookId', 'googleId', 'appleId' ];
 
   constructor(
     @InjectModel(User.name) private userModel: Model<User>,


### PR DESCRIPTION
User's private IDs were being leaked and can be accessed by `/api/user/[username]`
